### PR TITLE
pick_rgplugin_stype: New function, use where necessary

### DIFF
--- a/vsrgtools/rgtools.py
+++ b/vsrgtools/rgtools.py
@@ -124,9 +124,9 @@ def backward_clense(clip: vs.VideoNode, planes: PlanesT = None) -> vs.VideoNode:
     return pick_rgplugin_stype(clip, backward_clense).BackwardClense(planes)
 
 
-def vertical_cleaner(clip: vs.VideoNode, mode: VerticalCleanerModeT) -> vs.VideoNode:
-    return pick_rgplugin_stype(clip, vertical_cleaner).VerticalCleaner(mode)
+def vertical_cleaner(clip: vs.VideoNode, mode: VerticalCleanerModeT, func_except: FuncExceptT | None = None) -> vs.VideoNode:
+    return pick_rgplugin_stype(clip, func_except or vertical_cleaner).VerticalCleaner(mode)
 
 
 def horizontal_cleaner(clip: vs.VideoNode, mode: VerticalCleanerModeT) -> vs.VideoNode:
-    return vertical_cleaner(clip.std.Transpose(), mode).std.Transpose()
+    return vertical_cleaner(clip.std.Transpose(), mode, horizontal_cleaner).std.Transpose()


### PR DESCRIPTION
Closes #43.

This introduces a new function to replace `vstools.pick_func_stype` with a specialised one for removegrain plugins. This means the user is no longer required to have both rgvs and RGSF installed for functions to work, and that once zsmooth (https://github.com/adworacz/zsmooth?tab=readme-ov-file#implemented-featuresfunctions) has implemented every function called here, we can easily make use of it here if available.

This also returns "DependencyNotFound" errors as used in other JET packages.