### PR TITLE
Rewrite BlurMatrix

### DIFF
--- a/vsrgtools/blur.py
+++ b/vsrgtools/blur.py
@@ -11,7 +11,7 @@ from vstools import (
     split, to_arr, vs
 )
 
-from .enum import BlurMatrix, LimitFilterMode
+from .enum import BlurMatrix, BlurMatrixBase, LimitFilterMode
 from .limit import limit_filter
 from .util import normalize_radius
 
@@ -191,7 +191,9 @@ def gauss_blur(
 
     no_resize2 = not hasattr(core, 'resize2')
 
-    kernel = BlurMatrix.GAUSS(sigma, taps, 1.0 if no_resize2 and taps > 12 else 1023, mode)
+    kernel: BlurMatrixBase[float] = BlurMatrix.GAUSS(  # type: ignore
+        taps, sigma=sigma, mode=mode, scale_value=1.0 if no_resize2 and taps > 12 else 1023
+    )
 
     if len(kernel) <= 25:
         return kernel(clip, planes)

--- a/vsrgtools/blur.py
+++ b/vsrgtools/blur.py
@@ -191,10 +191,10 @@ def gauss_blur(
 
     no_resize2 = not hasattr(core, 'resize2')
 
-    kernel = BlurMatrix.GAUSS(sigma, taps, 1.0 if no_resize2 and taps > 12 else 1023)
+    kernel = BlurMatrix.GAUSS(sigma, taps, 1.0 if no_resize2 and taps > 12 else 1023, mode)
 
     if len(kernel) <= 25:
-        return kernel(clip, planes, mode)
+        return kernel(clip, planes)
 
     if no_resize2:
         if not complexpr_available:

--- a/vsrgtools/contra.py
+++ b/vsrgtools/contra.py
@@ -87,7 +87,7 @@ def contrasharpening_dehalo(
 
     rep_modes = norm_rmode_planes(flt, RepairMode.MINMAX_SQUARE1, planes)
 
-    weighted = BlurMatrix.WMEAN(flt, planes)
+    weighted = BlurMatrix.WMEAN()(flt, planes)
     weighted2 = median_blur(weighted, 2, planes=planes)
     weighted2 = iterate(weighted2, partial(repair, repairclip=weighted), 2, mode=rep_modes)
 

--- a/vsrgtools/enum.py
+++ b/vsrgtools/enum.py
@@ -169,7 +169,7 @@ class BlurMatrix(CustomIntEnum):
             self,
             taps: int | None = None,
             *,
-            sigma: float = 0.25,
+            sigma: float = 0.5,
             mode: ConvMode = ConvMode.HV,
             **kwargs: Any
         ) -> BlurMatrixBase[float]:

--- a/vsrgtools/rgtools.py
+++ b/vsrgtools/rgtools.py
@@ -61,17 +61,17 @@ def removegrain(clip: vs.VideoNode, mode: RemoveGrainModeT) -> vs.VideoNode:
     for idx, m in enumerate(mode):
         if m == RemoveGrainMode.SQUARE_BLUR:
             if all(mm == m for mm in mode):
-                return BlurMatrix.WMEAN(clip)
+                return BlurMatrix.WMEAN()(clip)
             expr.append(aka_removegrain_expr_11_12())
         elif RemoveGrainMode.BOB_TOP_CLOSE <= m <= RemoveGrainMode.BOB_BOTTOM_INTER:
             return pick_func_stype(clip, clip.rgvs.RemoveGrain, clip.rgsf.RemoveGrain)(mode)
         elif m == RemoveGrainMode.CIRCLE_BLUR:
             if set(mode) == {RemoveGrainMode.CIRCLE_BLUR}:
-                return BlurMatrix.CIRCLE(clip)
+                return BlurMatrix.CIRCLE()(clip)
             expr.append(aka_removegrain_expr_19())
         elif m == RemoveGrainMode.BOX_BLUR:
             if set(mode) == {RemoveGrainMode.BOX_BLUR}:
-                return BlurMatrix.MEAN(clip)
+                return BlurMatrix.MEAN()(clip)
             expr.append(aka_removegrain_expr_20())
         elif m == RemoveGrainMode.EDGE_DEHALO:
             expr.append(aka_removegrain_expr_23(0 if idx == 0 else -0.5))

--- a/vsrgtools/sharp.py
+++ b/vsrgtools/sharp.py
@@ -47,7 +47,7 @@ def unsharp_masked(
     if isinstance(radius, list):
         return normalize_radius(clip, unsharp_masked, radius, planes, strength=strength)
 
-    blurred = BlurMatrix.LOG(radius, strength)(clip, planes)
+    blurred = BlurMatrix.LOG(radius, strength=strength)(clip, planes)
 
     return norm_expr([clip, blurred], 'x dup y - +')
 

--- a/vsrgtools/sharp.py
+++ b/vsrgtools/sharp.py
@@ -61,13 +61,13 @@ def limit_usm(
     if callable(blur):
         blurred = blur(clip)
     elif isinstance(blur, vs.VideoNode):
-        blurred = blur  # type: ignore
-    elif blur <= 0:  # type: ignore
-        blurred = min_blur(clip, -blur, planes)  # type: ignore
+        blurred = blur
+    elif blur <= 0:
+        blurred = min_blur(clip, -blur, planes)
     elif blur == 1:
-        blurred = BlurMatrix.WMEAN(clip, planes)
+        blurred = BlurMatrix.WMEAN()(clip, planes)
     elif blur == 2:
-        blurred = BlurMatrix.MEAN(clip, planes)
+        blurred = BlurMatrix.MEAN()(clip, planes)
     else:
         raise CustomTypeError("'blur' must be an int, clip or a blurring function!", limit_usm, blur)
 

--- a/vsrgtools/util.py
+++ b/vsrgtools/util.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Sequence, TypeVar, cast
 
 from vstools import (
-    GenericVSFunction, KwargsT, Nb, PlanesT, check_variable, check_variable_format, join, normalize_planes,
+    ConvMode, GenericVSFunction, KwargsT, Nb, PlanesT, check_variable, check_variable_format, join, normalize_planes,
     normalize_seq, plane, vs
 )
 
@@ -15,8 +15,8 @@ __all__ = [
     'normalize_radius'
 ]
 
-wmean_matrix = list(BlurMatrix.WMEAN)
-mean_matrix = list(BlurMatrix.MEAN)
+wmean_matrix = list(BlurMatrix.WMEAN(1, ConvMode.SQUARE))
+mean_matrix = list(BlurMatrix.MEAN(1, ConvMode.SQUARE))
 
 RModeT = TypeVar('RModeT', RemoveGrainMode, RepairMode)
 

--- a/vsrgtools/util.py
+++ b/vsrgtools/util.py
@@ -15,8 +15,8 @@ __all__ = [
     'normalize_radius'
 ]
 
-wmean_matrix = list(BlurMatrix.WMEAN(1, ConvMode.SQUARE))
-mean_matrix = list(BlurMatrix.MEAN(1, ConvMode.SQUARE))
+wmean_matrix = list(BlurMatrix.WMEAN(1, mode=ConvMode.SQUARE))
+mean_matrix = list(BlurMatrix.MEAN(1, mode=ConvMode.SQUARE))
 
 RModeT = TypeVar('RModeT', RemoveGrainMode, RepairMode)
 


### PR DESCRIPTION
Changes:
- Remove `tosize(s)` methods as they silently clip the matrices if the length > 25
- Remove `asint` and `asfloat` methods
- Fix BlurMatrix for one-dimensional convolution mode
- Add BINOMIAL BlurMatrix
- GAUSS is now compatible with ConvMode.SQUARE