### PR TITLE
Fix ExprOp usage

### DIFF
--- a/vsrgtools/blur.py
+++ b/vsrgtools/blur.py
@@ -216,13 +216,13 @@ def sbr(
 
 
 def median_blur(
-    clip: vs.VideoNode, radius: int | list[int] = 1, mode: ConvMode = ConvMode.HV, planes: PlanesT = None
+    clip: vs.VideoNode, radius: int | list[int] = 1, mode: ConvMode = ConvMode.SQUARE, planes: PlanesT = None
 ) -> vs.VideoNode:
     if radius == 1 and mode in (ConvMode.HV, ConvMode.SQUARE):
         return clip.std.Median(planes=planes)
 
     def _get_vals(radius: int) -> tuple[StrList, int, int, int]:
-        matrix = ExprOp.matrix('x', radius, mode, [(0, 0)])
+        matrix = ExprList(ExprOp.matrix('x', radius, mode, [(0, 0)]))
         rb = len(matrix) + 1
         st = rb - 1
         sp = rb // 2 - 1


### PR DESCRIPTION
- `resize2` is now the default in `gauss_blur` since it has similar speed and even faster sometimes.
- Default mode in `median_blur` is SQUARE since `std.Median` effectively works in a 3x3 convolution.
- `BlurMatrix.__call__` now supports FLOAT16 inputs, convolution > 25 weights and uses `akarin.Expr` for `ConvMode.SQUARE`