### PR TITLE
Bring back downscale approximation in gauss_blur

### DIFF
--- a/vsrgtools/blur.py
+++ b/vsrgtools/blur.py
@@ -164,7 +164,7 @@ def gauss_blur(
                 resize_kwargs.update(width=plane.width, height=plane.height)
 
                 plane = Bilinear.scale(plane, wdown, hdown)
-                sigma = Gaussian.sigma.from_fmtc(9)
+                sigma = 0.8952637851149309
                 taps = min(taps, 128)
             else:
                 resize_kwargs.update({f'force_{k}': k in mode for k in 'hv'})

--- a/vsrgtools/blur.py
+++ b/vsrgtools/blur.py
@@ -161,11 +161,11 @@ def gauss_blur(
                 if ConvMode.HORIZONTAL in mode:
                     wdown = round(max(round(wdown / sigma), 2) / 2) * 2
 
+                resize_kwargs.update(width=plane.width, height=plane.height)
+
                 plane = Bilinear.scale(plane, wdown, hdown)
                 sigma = Gaussian.sigma.from_fmtc(9)
                 taps = min(taps, 128)
-
-                resize_kwargs.update(width=plane.width, height=plane.height)
             else:
                 resize_kwargs.update({f'force_{k}': k in mode for k in 'hv'})
 


### PR DESCRIPTION
Related issue: https://github.com/Jaded-Encoding-Thaumaturgy/vs-rgtools/issues/42

Downscale approximation has a big speed gain when `taps` is large and can be used by specifying `_fast=True`.